### PR TITLE
fix #66 build error

### DIFF
--- a/sources/assets/callback/CMakeLists.txt
+++ b/sources/assets/callback/CMakeLists.txt
@@ -23,7 +23,7 @@ endif()
 
 
 
-if(WIN32 AND NOT HAKO_WIN32_SHARED_LIBS)
+if(WIN32)
 add_library(
     assets STATIC
     src/hako_asset.cpp

--- a/sources/conductor/CMakeLists.txt
+++ b/sources/conductor/CMakeLists.txt
@@ -13,7 +13,7 @@ endif(WIN32)
 MESSAGE(STATUS "OS_TYPE=" ${OS_TYPE})
 
 
-if(WIN32 AND NOT HAKO_WIN32_SHARED_LIBS)
+if(WIN32)
 add_library(
     conductor STATIC
     src/hako_conductor.cpp


### PR DESCRIPTION
issue #68 で報告していますが、assetsとconducotrは、shakoc.dllがリンクするようですので、Staticのままの方が良いかと思います。Windows環境だけかと思います。