### PR TITLE
change Visual Studio 2022 CMake options

### DIFF
--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -7,7 +7,7 @@
       "inheritEnvironments": [ "msvc_x64_x64" ],
       "buildRoot": "${projectDir}\\out\\build\\${name}",
       "installRoot": "${projectDir}\\out\\install\\${name}",
-      "cmakeCommandArgs": "",
+      "cmakeCommandArgs": "-DHAKO_CLIENT_OPTION_FILEPATH=\"cmake-options\\win-cmake-options.cmake\" -DHAKO_WIN32_SHARED_LIBS=ON",
       "buildCommandArgs": "",
       "ctestCommandArgs": ""
     },
@@ -17,7 +17,7 @@
       "configurationType": "RelWithDebInfo",
       "buildRoot": "${projectDir}\\out\\build\\${name}",
       "installRoot": "${projectDir}\\out\\install\\${name}",
-      "cmakeCommandArgs": "-DHAKO_CLIENT_OPTION_FILEPATH=\"cmake-options\\win-cmake-options.cmake\"",
+      "cmakeCommandArgs": "-DHAKO_CLIENT_OPTION_FILEPATH=\"cmake-options\\win-cmake-options.cmake\" -DHAKO_WIN32_SHARED_LIBS=ON",
       "buildCommandArgs": "",
       "ctestCommandArgs": "",
       "inheritEnvironments": [ "msvc_x64_x64" ]


### PR DESCRIPTION
Visual Studio 2022 Community版のCMake環境のオプションです。
Windows使いには必要かと思うので、アップしておきます。