### PR TITLE
Make core config install directory configurable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,10 +151,16 @@ install(
     DESTINATION include/hakoniwa/pdu
 )
 
+# Keep the historical system-wide location by default. CI, packaging, and
+# relocatable installs may override this with a relative path such as
+# "etc/hakoniwa", which is then resolved under CMAKE_INSTALL_PREFIX.
+set(HAKO_CORE_CONFIG_INSTALL_DIR "/etc/hakoniwa" CACHE STRING
+    "Install destination for cpp_core_config.json (absolute or relative to CMAKE_INSTALL_PREFIX)")
+
 # Install core config file
 install(
     FILES ${PROJECT_SOURCE_DIR}/hakoniwa-core-cpp/cpp_core_config.json
-    DESTINATION /etc/hakoniwa
+    DESTINATION "${HAKO_CORE_CONFIG_INSTALL_DIR}"
 )
 
 # Install PDU offset files


### PR DESCRIPTION
## Summary

Keep the historical `cpp_core_config.json` install location unchanged by default while allowing CI, packaging, and relocatable installs to override it.

## Changes

- add `HAKO_CORE_CONFIG_INSTALL_DIR` as a CMake cache variable
- default remains `/etc/hakoniwa` for zero behavioral change
- relative values such as `etc/hakoniwa` are resolved under `CMAKE_INSTALL_PREFIX`

Example for a relocatable/local install:

```bash
cmake -S . -B build \
  -DCMAKE_INSTALL_PREFIX=/tmp/hakoniwa-core \
  -DHAKO_CORE_CONFIG_INSTALL_DIR=etc/hakoniwa
cmake --build build
cmake --install build
```

This installs the config to:

```text
/tmp/hakoniwa-core/etc/hakoniwa/cpp_core_config.json
```

Existing builds that do not set the new variable continue to install the config to `/etc/hakoniwa`.

## Runtime note

Custom config locations remain opt-in at runtime through `HAKO_CONFIG_PATH`; the default runtime behavior is intentionally unchanged.
