### PR TITLE
Export Core frontend include requirements

### DIFF
--- a/sources/assets/callback/CMakeLists.txt
+++ b/sources/assets/callback/CMakeLists.txt
@@ -60,14 +60,18 @@ target_link_libraries(
 )
 target_include_directories(
     assets
-    PRIVATE /usr/local/include
-    PRIVATE ${HAKO_INC_DIR}
-    PRIVATE ${HAKO_CORE_SOURCE_DIR}/src/include
-    PRIVATE ${HAKO_CORE_SOURCE_DIR}/src/hako
-    PRIVATE ${HAKO_PDU_SOURCE_DIR}
-    PRIVATE ${HAKO_CORE_PRO_SOURCE_DIR}/core/include
-    PRIVATE ${HAKO_CORE_PRO_SOURCE_DIR}/core/src/service
-    PRIVATE ${nlohmann_json_SOURCE_DIR}/single_include
+    PUBLIC
+        $<BUILD_INTERFACE:${HAKO_INC_DIR}>
+        $<BUILD_INTERFACE:${HAKO_PDU_SOURCE_DIR}>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/hakoniwa>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/hakoniwa/pdu>
+    PRIVATE
+        /usr/local/include
+        ${HAKO_CORE_SOURCE_DIR}/src/include
+        ${HAKO_CORE_SOURCE_DIR}/src/hako
+        ${HAKO_CORE_PRO_SOURCE_DIR}/core/include
+        ${HAKO_CORE_PRO_SOURCE_DIR}/core/src/service
+        ${nlohmann_json_SOURCE_DIR}/single_include
 )
 set_target_properties(assets PROPERTIES VERSION 1.0.0 SOVERSION 1)
 

--- a/sources/assets/polling/CMakeLists.txt
+++ b/sources/assets/polling/CMakeLists.txt
@@ -90,14 +90,18 @@ target_link_libraries(
 
 target_include_directories(
     shakoc
-    PRIVATE /usr/local/include
-    PRIVATE ${HAKO_CORE_SOURCE_DIR}/src/include
-    PRIVATE ${HAKO_CORE_SOURCE_DIR}/src/hako
-    PRIVATE ${HAKO_PDU_SOURCE_DIR}
-    PRIVATE ${nlohmann_json_SOURCE_DIR}/single_include
-    PRIVATE ${HAKO_INC_DIR}
-    PRIVATE ${HAKO_CORE_PRO_SOURCE_DIR}/core/include
-    PRIVATE ${HAKO_CORE_PRO_SOURCE_DIR}/core/src/service
+    PUBLIC
+        $<BUILD_INTERFACE:${HAKO_INC_DIR}>
+        $<BUILD_INTERFACE:${HAKO_PDU_SOURCE_DIR}>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/hakoniwa>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/hakoniwa/pdu>
+    PRIVATE
+        /usr/local/include
+        ${HAKO_CORE_SOURCE_DIR}/src/include
+        ${HAKO_CORE_SOURCE_DIR}/src/hako
+        ${nlohmann_json_SOURCE_DIR}/single_include
+        ${HAKO_CORE_PRO_SOURCE_DIR}/core/include
+        ${HAKO_CORE_PRO_SOURCE_DIR}/core/src/service
 )
 
 set_target_properties(shakoc PROPERTIES VERSION 1.0.0 SOVERSION 1)


### PR DESCRIPTION
## Summary

Make the installed Hakoniwa Core frontend targets usable as normal CMake package dependencies.

## Changes

- export public build/install include requirements from `assets`
- export public build/install include requirements from `shakoc`
- keep internal Core source include paths private
- preserve the existing library composition and Windows static/shared behavior

## Why

`hakoniwa-pdu-endpoint` is moving its Core-aware variants to a proper external CMake package contract. That requires consumers to be able to link `hakoniwa-core::assets` or `hakoniwa-core::shakoc` and receive the public Hakoniwa include paths transitively instead of reconstructing Core include paths manually.

This is a packaging/usage-requirement change only; no runtime API or default behavior is changed.