### PR TITLE
Fix relocatable Core include export

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,11 @@ project(hakoniwa-core-pro
     LANGUAGES C CXX
 )
 
+# Define the standard install directory variables before any subdirectory creates
+# install/export usage requirements. In particular, assets and shakoc publish
+# INSTALL_INTERFACE paths based on CMAKE_INSTALL_INCLUDEDIR.
+include(GNUInstallDirs)
+
 enable_testing()
 
 set(HAKO_CORE_SOURCE_DIR "${PROJECT_SOURCE_DIR}/hakoniwa-core-cpp")
@@ -104,7 +109,6 @@ add_subdirectory(tests/cpp)
 endif()
 
 # For pkg-config support
-include(GNUInstallDirs)
 configure_file(
   cmake/hakoniwa-core.pc.in
   ${CMAKE_BINARY_DIR}/hakoniwa-core.pc


### PR DESCRIPTION
## Summary

Fix the installed CMake package export so `assets` and `shakoc` do not emit an invalid `/hakoniwa` include path when Hakoniwa Core Pro is installed to a non-default prefix.

## Root cause

`assets` and `shakoc` publish install usage requirements based on `${CMAKE_INSTALL_INCLUDEDIR}`, but the root `CMakeLists.txt` called `include(GNUInstallDirs)` only after those subdirectories had already been added. At that point the variable could still be empty, producing exported paths such as `/hakoniwa`.

This was reproduced during the macOS Shadow Hand integration check with an isolated install prefix.

## Change

- load `GNUInstallDirs` immediately after the root `project()` call
- keep the existing install layout and default behavior unchanged
- remove the later redundant `include(GNUInstallDirs)` call

No runtime API, Core composition, default config location, or Windows static/shared policy is changed.

## Validation context

With `CMAKE_INSTALL_INCLUDEDIR=include` explicitly supplied as a workaround during the reproduction, the following all succeeded on macOS arm64:

- Core install to an isolated prefix
- Endpoint base / `core_callback` / `core_polling` builds
- external Endpoint package consumers
- Bridge `hakoniwa-pdu-web-bridge`
- Foxglove build/tests against the installed Endpoint package
- Shadow Hand -> Bridge -> TCP -> CDR -> Foxglove runtime E2E

After this PR is merged, the downstream Endpoint and Bridge package-contract CI should be rerun against Core Pro `main` to confirm the workaround is no longer necessary.