### PR TITLE
Add standard hako.py doctor and build entry point

### DIFF
--- a/tools/hako.py
+++ b/tools/hako.py
@@ -17,6 +17,14 @@ def repo_root() -> Path:
     return Path(__file__).resolve().parents[1]
 
 
+def powershell() -> str:
+    for name in ("pwsh", "powershell.exe", "powershell"):
+        found = shutil.which(name)
+        if found:
+            return found
+    raise HakoError("PowerShell was not found on PATH")
+
+
 def doctor() -> int:
     root = repo_root()
     checks: list[tuple[str, bool, str]] = []
@@ -29,6 +37,16 @@ def doctor() -> int:
     checks.append(("hakoniwa-core-cpp", cpp.is_dir(), str(cpp)))
     checks.append(("build defaults", (root / "cmake" / "hako_build_defaults.conf").is_file(), "cmake/hako_build_defaults.conf"))
     checks.append(("CMakeLists.txt", (root / "CMakeLists.txt").is_file(), "CMakeLists.txt"))
+
+    if sys.platform == "win32":
+        win_build = root / "win-build.ps1"
+        checks.append(("Windows build driver", win_build.is_file(), "win-build.ps1"))
+        ps = next((shutil.which(name) for name in ("pwsh", "powershell.exe", "powershell") if shutil.which(name)), None)
+        checks.append(("PowerShell", ps is not None, ps or "not found"))
+    else:
+        build_script = root / "build.bash"
+        checks.append(("POSIX build driver", build_script.is_file(), "build.bash"))
+        checks.append(("Bash", shutil.which("bash") is not None, shutil.which("bash") or "not found"))
 
     print(f"Platform: {platform.system()} {platform.machine()}")
     failed = False
@@ -47,15 +65,24 @@ def doctor() -> int:
 def build(native_args: list[str]) -> int:
     root = repo_root()
     if sys.platform == "win32":
-        raise HakoError(
-            "native Windows build is not standardized in this repository yet; "
-            "use the existing supported environment or add a component-owned Windows build driver first"
-        )
+        script = root / "win-build.ps1"
+        if not script.is_file():
+            raise HakoError(f"Windows build script not found: {script}")
+        cmd = [
+            powershell(),
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(script),
+            *native_args,
+        ]
+    else:
+        script = root / "build.bash"
+        if not script.is_file():
+            raise HakoError(f"build script not found: {script}")
+        cmd = ["bash", str(script), *native_args]
 
-    script = root / "build.bash"
-    if not script.is_file():
-        raise HakoError(f"build script not found: {script}")
-    cmd = ["bash", str(script), *native_args]
     print(">", subprocess.list2cmdline(cmd))
     return subprocess.run(cmd, cwd=root, check=False).returncode
 
@@ -64,7 +91,7 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Standard entry point for hakoniwa-core-pro")
     sub = parser.add_subparsers(dest="command", required=True)
     sub.add_parser("doctor", help="check build prerequisites")
-    build_parser = sub.add_parser("build", help="delegate to the existing component build")
+    build_parser = sub.add_parser("build", help="delegate to the existing platform build")
     build_parser.add_argument("native_args", nargs=argparse.REMAINDER)
     args = parser.parse_args(argv)
 

--- a/tools/hako.py
+++ b/tools/hako.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import platform
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+class HakoError(RuntimeError):
+    pass
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def doctor() -> int:
+    root = repo_root()
+    checks: list[tuple[str, bool, str]] = []
+
+    checks.append(("Python", sys.version_info >= (3, 8), sys.version.split()[0]))
+    checks.append(("CMake", shutil.which("cmake") is not None, shutil.which("cmake") or "not found"))
+    checks.append(("Git", shutil.which("git") is not None, shutil.which("git") or "not found"))
+
+    cpp = root / "hakoniwa-core-cpp"
+    checks.append(("hakoniwa-core-cpp", cpp.is_dir(), str(cpp)))
+    checks.append(("build defaults", (root / "cmake" / "hako_build_defaults.conf").is_file(), "cmake/hako_build_defaults.conf"))
+    checks.append(("CMakeLists.txt", (root / "CMakeLists.txt").is_file(), "CMakeLists.txt"))
+
+    print(f"Platform: {platform.system()} {platform.machine()}")
+    failed = False
+    for name, ok, detail in checks:
+        print(f"[{'OK' if ok else 'NG'}] {name}: {detail}")
+        failed = failed or not ok
+
+    if failed:
+        print("Doctor found missing build prerequisites.", file=sys.stderr)
+        return 1
+
+    print("Doctor passed.")
+    return 0
+
+
+def build(native_args: list[str]) -> int:
+    root = repo_root()
+    if sys.platform == "win32":
+        raise HakoError(
+            "native Windows build is not standardized in this repository yet; "
+            "use the existing supported environment or add a component-owned Windows build driver first"
+        )
+
+    script = root / "build.bash"
+    if not script.is_file():
+        raise HakoError(f"build script not found: {script}")
+    cmd = ["bash", str(script), *native_args]
+    print(">", subprocess.list2cmdline(cmd))
+    return subprocess.run(cmd, cwd=root, check=False).returncode
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Standard entry point for hakoniwa-core-pro")
+    sub = parser.add_subparsers(dest="command", required=True)
+    sub.add_parser("doctor", help="check build prerequisites")
+    build_parser = sub.add_parser("build", help="delegate to the existing component build")
+    build_parser.add_argument("native_args", nargs=argparse.REMAINDER)
+    args = parser.parse_args(argv)
+
+    if args.command == "doctor":
+        return doctor()
+    if args.command == "build":
+        native_args = args.native_args
+        if native_args and native_args[0] == "--":
+            native_args = native_args[1:]
+        return build(native_args)
+    raise HakoError(f"unsupported command: {args.command}")
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except HakoError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        raise SystemExit(2)


### PR DESCRIPTION
## Summary

Add the common `tools/hako.py` entry point to `hakoniwa-core-pro` so the foundational Hakoniwa runtime exposes the same basic operational contract as Endpoint, Bridge, RPC, and MuJoCo.

## Scope

This is intentionally small. The Endpoint modernization already absorbed most of the difficult cross-platform dependency/build reasoning, so Core PRO does not duplicate that resolver.

- add `python tools/hako.py doctor` for lightweight prerequisite and repository-layout checks;
- add `python tools/hako.py build` as a thin platform dispatcher;
- delegate Linux/macOS builds to the existing `build.bash`;
- delegate native Windows builds to the existing `win-build.ps1`;
- check the OS-specific build driver as part of doctor;
- do not change Core runtime behavior, CMake configuration, tests, or existing build scripts.

## Why

The goal is interface consistency rather than new build logic:

```text
python tools/hako.py doctor
python tools/hako.py build
```

becomes the common first-touch contract for the major Hakoniwa C++ components, while component-specific implementation remains owned by each repository.

## Validation

The new entry point is dependency-light and delegates the actual build to the existing platform-native scripts. Existing build semantics are unchanged.