### PR TITLE
Expose minimum asset time to Python

### DIFF
--- a/sources/assets/bindings/python/src/hako_asset_python.cpp
+++ b/sources/assets/bindings/python/src/hako_asset_python.cpp
@@ -185,6 +185,11 @@ static PyObject* py_hako_asset_current_time(PyObject*, PyObject*) {
 
     return PyLong_FromLongLong(current_time);
 }
+static PyObject* py_hako_asset_min_asset_time(PyObject*, PyObject*) {
+    hako_time_t min_asset_time = hako_asset_min_asset_time();
+
+    return PyLong_FromLongLong(min_asset_time);
+}
 static PyObject* py_hako_asset_usleep(PyObject*, PyObject* args) {
     hako_time_t sleep_time_usec;
 
@@ -921,6 +926,7 @@ static PyMethodDef hako_asset_python_methods[] = {
     {"start", py_hako_asset_start, METH_VARARGS, "Start the asset."},
     {"simulation_time", py_hako_asset_simulation_time, METH_NOARGS, "Get the current simulation time."},
     {"asset_current_time", py_hako_asset_current_time, METH_NOARGS, "Get the current asset time."},
+    {"min_asset_time", py_hako_asset_min_asset_time, METH_NOARGS, "Get the minimum simulation time reported by registered assets."},
     {"usleep", py_hako_asset_usleep, METH_VARARGS, "Sleep for the specified time in microseconds."},
     {"pdu_read", py_hako_asset_pdu_read, METH_VARARGS, "Read PDU data for the specified robot name and channel ID."},
     {"pdu_write", py_hako_asset_pdu_write, METH_VARARGS, "Write PDU data for the specified robot name and channel ID."},

--- a/tests/assets/bindings/python/test.py
+++ b/tests/assets/bindings/python/test.py
@@ -50,6 +50,11 @@ def main():
         print(f"ERROR: hako_asset_register() returns {ret}.")
         return 1
 
+    min_asset_time = hakopy.min_asset_time()
+    if not isinstance(min_asset_time, int) or min_asset_time < 0:
+        print(f"ERROR: hakopy.min_asset_time() returns invalid value: {min_asset_time}")
+        return 1
+
     ret = hakopy.start()
     print(f"INFO: hako_asset_start() returns {ret}")
 


### PR DESCRIPTION
## Summary

Expose the existing `hako_asset_min_asset_time()` C API through the `hakopy` Python binding as:

```python
hakopy.min_asset_time()
```

The API returns the minimum simulation time currently reported by the registered Assets.

## Why

This supports non-invasive external observation of Hakoniwa virtual-time behavior from Python. In particular, an observer can sample `hakopy.simulation_time()` together with `hakopy.min_asset_time()` without modifying the Core time-coordination algorithm.

## Changes

- add a Python wrapper for the existing `hako_asset_min_asset_time()` API
- register `hakopy.min_asset_time()` in the Python method table
- extend the existing Python binding test to verify the API returns a non-negative integer after Asset registration

## Scope

This PR only exposes an existing read API to Python. It does **not** change Core time progression, synchronization logic, shared-memory layout, or Asset time update behavior.

## Validation

- diff checked: 2 files, 11 added lines, no deletions
- existing Python binding test extended to exercise the new API
- CI should provide the build/runtime validation for the binding on the supported environments
